### PR TITLE
fix(coverage): use test page instead of index

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ const configuration = {
     src: {
       css: 'lib/**/*.css',
       html: 'lib/index.dev.html',
+      testHtml: 'test/test.html',
       js: 'lib/**/*.js',
       vendor: 'lib/vendor/*'
     },
@@ -38,6 +39,13 @@ gulp.task('clean', function () {
     './dist/*',
     '!./dist/.gitignore'
   ]);
+
+});
+
+gulp.task('testHtml', function () {
+
+  return gulp.src(configuration.paths.src.testHtml)
+    .pipe(gulp.dest(configuration.paths.dist));
 
 });
 
@@ -119,7 +127,7 @@ gulp.task('dev', gulp.parallel(['connect', 'open', 'watch']));
 
 gulp.task('default', gulp.series(['clean', 'html', 'css', 'js', 'vendor']));
 
-gulp.task('test', gulp.series(['default'], function (done) {
+gulp.task('test', gulp.series(['default', 'testHtml'], function (done) {
 
   return new KarmaServ({
     configFile: `${configuration.paths.test}/config/karma.unit.js`,

--- a/lib/main/main.js
+++ b/lib/main/main.js
@@ -118,13 +118,17 @@ function initKeyboardBindings () {
 
 function _init () {
 
-  mrflap = $('.mrflap-playground');
-  appendHeader();
-  appendFooter();
-  initCanvas();
-  initKeyboardBindings();
-  initGravity();
-  spawnObstacles();
+  if ($('.mrflap-playground').length) {
+
+    mrflap = $('.mrflap-playground');
+    appendHeader();
+    appendFooter();
+    initCanvas();
+    initKeyboardBindings();
+    initGravity();
+    spawnObstacles();
+  
+  }
 
 };
 

--- a/test/canvas/canvasSpec.js
+++ b/test/canvas/canvasSpec.js
@@ -3,10 +3,17 @@
 describe('Canvas', function () {
     
   var mrflapDiv;
+
+  const _initPlayground = function () {
+
+    $('body').append('<div class="mrflap-playground"></div>');
+  
+  };
   
   beforeEach(function () {
   
-    document.body.innerHTML = __html__['index.html'];
+    document.body.innerHTML = __html__['test.html'];
+    _initPlayground();
     mrflapDiv = $('.mrflap-playground');
     
   });

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -3,10 +3,18 @@
 
 describe('Demo index page', function () {
 
+  const _initPlayground = function () {
+
+    $('body').append('<div class="mrflap-playground"></div>');
+  
+  };
+
   it('should expose the templates to __html__', function () {
 
     // given
-    document.body.innerHTML = __html__['index.html'];
+    document.body.innerHTML = __html__['test.html'];
+
+    _initPlayground;
 
     // when
     var playground = $('.mrflap-playground');

--- a/test/main/mainSpec.js
+++ b/test/main/mainSpec.js
@@ -2,12 +2,20 @@
 /* eslint-disable no-unused-expressions */
 describe('Main', function () {
   
+  const _initPlayground = function () {
+
+    $('body').append('<div class="mrflap-playground"></div>');
+  
+  };
+  
   describe('#_init', function (done) {
       
     before(function () {
       
       // given
-      document.body.innerHTML = __html__['index.html'];
+      document.body.innerHTML = __html__['test.html'];
+
+      _initPlayground();
 
       // when
       _init();

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="./mrflap.dev.css">
+
+        <script type="text/javascript" src="./mrflap.dev.js"></script>
+    </head>
+
+    <body>
+
+    </body>
+</html>


### PR DESCRIPTION
Closes #16 
Closes #32 

Now you have to append the playground + operate the `_init` function to execute the full application in the tests. This leads that this code will not be executed in every tests where the html file is loaded. This seems to fix #16, I tested it by creating a code snippet inside `bird.js` (which is not used from `main.js`)

![image](https://user-images.githubusercontent.com/9433996/50677088-2e069480-0ff8-11e9-84da-cac58830ba15.png)

Before using it inside the `birdSpec`:

![image](https://user-images.githubusercontent.com/9433996/50677131-63ab7d80-0ff8-11e9-987e-5de3d22766e8.png)

After using it inside the `birdSpec`:

![image](https://user-images.githubusercontent.com/9433996/50677149-7faf1f00-0ff8-11e9-890b-b4e6e6713fa6.png)

So the coverage report belongs to the `birdSpec` now, instead of only using the `mainSpec`.

Tested under `macOS.14.2`